### PR TITLE
Add Archivo Narrow font

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://images.pexels.com/photos/376464/pexels-photo-376464.jpeg" />
     <title>Glaz - Restaurant Français Moderne à Paris</title>
+    <link href="https://fonts.googleapis.com/css2?family=Archivo+Narrow:wght@400;700&display=swap" rel="stylesheet">
     <style>
       .text-shadow { text-shadow: 2px 2px 4px rgba(0,0,0,0.5); }
       .text-shadow-lg { text-shadow: 3px 3px 6px rgba(0,0,0,0.7); }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Archivo+Narrow:wght@400;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family: 'Archivo Narrow', sans-serif;
+}


### PR DESCRIPTION
## Summary
- import Archivo Narrow via Google Fonts
- apply the font globally

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867d61a9f848331b1343eff1bf7b90e