### PR TITLE
Add Orbitron Black font

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://images.pexels.com/photos/376464/pexels-photo-376464.jpeg" />
     <title>Glaz - Restaurant Français Moderne à Paris</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@900&display=swap" rel="stylesheet">
     <style>
       .text-shadow { text-shadow: 2px 2px 4px rgba(0,0,0,0.5); }
       .text-shadow-lg { text-shadow: 3px 3px 6px rgba(0,0,0,0.7); }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -62,9 +62,9 @@ const Hero = () => {
       <div className="absolute inset-0 flex items-center justify-center text-center text-white px-6">
         <div className="max-w-4xl">
           <h1 className="text-5xl md:text-7xl font-bold mb-6 text-shadow-lg">
-            Bienvenue chez
-            <span className="block text-6xl md:text-8xl text-amber-300 font-serif italic">
-              Glaz
+            Bienvenue au
+            <span className="block text-6xl md:text-8xl text-white">
+              glaz
             </span>
           </h1>
           <p className="text-xl md:text-2xl mb-4 text-shadow">

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family: 'Orbitron', sans-serif;
+  font-weight: 900;
+}


### PR DESCRIPTION
## Summary
- import Orbitron Black from Google Fonts
- apply the font globally
- change hero title to say "Bienvenue au glaz" in white

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867d61a9f848331b1343eff1bf7b90e